### PR TITLE
Updated Dartlang URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For Angular [Angular](http://angulardart.io)
 
 ## * Dartlang and AngularDart
 
-For Dartlang please visit [Dartlang](https://www.dartlang.org) and [Github repo](https://github.com/dart-lang),
+For Dartlang please visit [Dartlang](https://dart.dev/) and [Github repo](https://github.com/dart-lang),
 For AngularDart [AngularDart](http://angulardart.org) and [Github](https://github.com/dart-lang/angular)
 ```I love Dart```
 


### PR DESCRIPTION
The URL has been changed to https://dart.dev/